### PR TITLE
fix: propagate stream read error

### DIFF
--- a/src/protocols/reading.rs
+++ b/src/protocols/reading.rs
@@ -209,7 +209,7 @@ where
             // a stream read error
             Err(e) => {
                 error!(parent: self.node().span(), "can't read from {}: {}", addr, e);
-                Err(io::ErrorKind::Other.into())
+                Err(e)
             }
         }
     }


### PR DESCRIPTION
Stream read errors weren't being propagated and thus were never checked for being "fatal". 