### PR TITLE
Expose the connection side for an address in top-level public API

### DIFF
--- a/examples/libp2p.rs
+++ b/examples/libp2p.rs
@@ -168,7 +168,7 @@ impl Encoder<yamux::Frame> for Codec {
 // payloads for Noise handshake messages
 // note: this struct was auto-generated using prost-build based on
 // the proto file from the libp2p-noise repository
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct NoiseHandshakePayload {
     #[prost(bytes = "vec", tag = "1")]
     pub identity_key: ::prost::alloc::vec::Vec<u8>,

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -25,6 +25,10 @@ impl Connections {
         self.0.read().contains_key(&addr)
     }
 
+    pub(crate) fn connection_side(&self, addr: SocketAddr) -> Option<ConnectionSide> {
+        self.0.read().get(&addr).map(|conn| conn.side())
+    }
+
     pub(crate) fn remove(&self, addr: SocketAddr) -> Option<Connection> {
         self.0.write().remove(&addr)
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -375,6 +375,11 @@ impl Node {
         self.connections.is_connected(addr)
     }
 
+    /// Returns the connection side of the provided address.
+    pub fn connection_side(&self, addr: SocketAddr) -> Option<ConnectionSide> {
+        self.connections.connection_side(addr)
+    }
+
     /// Checks if the node is currently setting up a connection with the provided address.
     pub fn is_connecting(&self, addr: SocketAddr) -> bool {
         self.connecting.lock().contains(&addr)


### PR DESCRIPTION
This PR adds a `connection_side` method on the `Node` to expose the `ConnectionSide` for a specific address. This makes it easy to implement connection direction-based logic outside of the handshake (which is the only place this information is currently available). 